### PR TITLE
Add Phoenix webhooks meetup (and templating changes)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,15 @@ But what happens if they&#039;re not secure? What happens if your webhooks are i
 In this session, we&#039;ll delve into the 100+ implementations we explored to build webhooks. fyi to identify the best and worst patterns to protect our systems now and in the future.
 		<br>
 					RSVP:
-							<a href="https://www.meetup.com/atlantaphp/events/291892502/">Atlanta</a>, 							<a href="https://www.meetup.com/austinphp/events/xsbbctyfcfbmb/">Austin</a>, 							<a href="https://www.meetup.com/kcphpug/events/zlfpzsyfcfbmb/">Kansas City</a>, 							<a href="https://www.meetup.com/vegas-programmers/events/291655784/">Las Vegas</a>, 							<a href="https://www.meetup.com/sandiegophp/events/292081010/">San Diego</a>,							<a href="https://www.meetup.com/seaphp/events/291540671/">Seattle</a>, 							<a href="https://www.meetup.com/utah-php-user-group/events/292010849/">Utah</a>						</section>
+							<a href="https://www.meetup.com/atlantaphp/events/291892502/">Atlanta</a>, 
+							<a href="https://www.meetup.com/austinphp/events/xsbbctyfcfbmb/">Austin</a>, 
+							<a href="https://www.meetup.com/kcphpug/events/zlfpzsyfcfbmb/">Kansas City</a>, 
+							<a href="https://www.meetup.com/vegas-programmers/events/291655784/">Las Vegas</a>, 
+							<a href="https://www.meetup.com/azphpug/events/292088678/">Phoenix</a>, 
+							<a href="https://www.meetup.com/sandiegophp/events/292081010/">San Diego</a>, 
+							<a href="https://www.meetup.com/seaphp/events/291540671/">Seattle</a>, 
+							<a href="https://www.meetup.com/utah-php-user-group/events/292010849/">Utah</a>
+						</section>
 
 <a href="/meetups/2023/">View past meetups</a>
 

--- a/src/Meetup/Meetup20230309WebhooksTheGoodTheBadAndTheUgly.php
+++ b/src/Meetup/Meetup20230309WebhooksTheGoodTheBadAndTheUgly.php
@@ -60,6 +60,7 @@ class Meetup20230309WebhooksTheGoodTheBadAndTheUgly extends AbstractMeetup
 			Meetups::Austin->value => 'https://www.meetup.com/austinphp/events/xsbbctyfcfbmb/',
 			Meetups::KansasCity->value => 'https://www.meetup.com/kcphpug/events/zlfpzsyfcfbmb/',
 			Meetups::LasVegas->value => 'https://www.meetup.com/vegas-programmers/events/291655784/',
+			Meetups::Phoenix->value => 'https://www.meetup.com/azphpug/events/292088678/',
 			Meetups::SanDiego->value => 'https://www.meetup.com/sandiegophp/events/292081010/',
 			Meetups::Seattle->value => 'https://www.meetup.com/seaphp/events/291540671/',
 			Meetups::Utah->value => 'https://www.meetup.com/utah-php-user-group/events/292010849/',

--- a/templates/archive.twig.html
+++ b/templates/archive.twig.html
@@ -10,7 +10,7 @@
 		<a href="{{ meetup.getPermalink() }}">
 			<img src="{{ meetup.getImage() }}" alt="{{ meetup.getTitle() }}">
 		</a>
-		<time datetime="{{ meetup.getDateTime()|date('c') }}">{{ meetup.getDateTime()|date('F jS, Y') }}</time>
+		<time datetime="{{ meetup.getDateTime().format('c') }}">{{ meetup.getDateTime()|date('F jS, Y') }}</time>
 
 		<p>
 			{{ meetup.getDescription()[:500] }}

--- a/templates/index.twig.html
+++ b/templates/index.twig.html
@@ -8,6 +8,7 @@
 	<ul>
 		{% for meetup in meetups %}
 			<li>{{ meetup }}</li>
+
 		{% endfor %}
 	</ul>
 </aside>
@@ -24,6 +25,7 @@
 			RSVP:
 			{% for name, link in nextMeetup.getMeetupLinks() %}
 				<a href="{{ link }}">{{name}}</a>{% if not loop.last %}, {% endif %}
+
 			{% endfor %}
 		{% endif %}
 	</section>

--- a/templates/index.twig.html
+++ b/templates/index.twig.html
@@ -15,7 +15,7 @@
 {% if nextMeetup %}
 	<section>
 		Join us on
-		<time datetime="{{ nextMeetup.getDateTime()|date('c') }}" style="display:inline">{{ nextMeetup.getDateTime()|date('F jS, Y') }}</time>
+		<time datetime="{{ nextMeetup.getDateTime().format('c') }}" style="display:inline">{{ nextMeetup.getDateTime()|date('F jS, Y') }}</time>
 		as {{ nextMeetup.getSpeakerName() }} presents
 		<a href="{{ nextMeetup.getPermalink() }}"><strong>{{ nextMeetup.getTitle() }}</strong></a>
 		<br>

--- a/templates/meetup.twig.html
+++ b/templates/meetup.twig.html
@@ -6,7 +6,7 @@
 
 		<img src="{{ meetup.getImage() }}" alt="{{ title }}">
 
-		<time datetime="{{ meetup.getDateTime()|date('c') }}">{{ meetup.getDateTime()|date('F jS, Y') }}</time>
+		<time datetime="{{ meetup.getDateTime().format('c') }}">{{ meetup.getDateTime()|date('F jS, Y') }}</time>
 	</header>
 
 	{% if meetup.getYouTubeLink() %}


### PR DESCRIPTION
I made a few tweaks to the templates so we don't end up with a ton of changes every time we generate - mainly around datetime formatting (it was using our local timezone and not that of the defined meetup)
Also added an extra line after each regional meetup link so our respective PRs are more atomic

If this is all okay, I'll do a separate PR to regenerate all the other pages with fixed datetimes