### PR TITLE
Run Actions on pull request only; do not run on push

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -5,9 +5,6 @@ on:
     pull_request:
         branches:
             - main
-    push:
-        branches-ignore:
-            -   main
 
 jobs:
     build-check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,6 @@ on:
     pull_request:
         branches:
             - main
-    push:
-        branches-ignore:
-            -   main
 
 jobs:
     lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     pull_request:
         branches:
             - main
-    push:
-        branches-ignore:
-            -   main
 
 jobs:
     test:


### PR DESCRIPTION
Actions run on every push to the branch when the PR is open; there is no need to run them on push as well