### PR TITLE
Upgrade PHP Code Sniffer, resolve PHPUnit deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
             -   name: Run PHPUnit Tests
                 uses: php-actions/phpunit@v3
                 with:
-                    args: --colors=always --testdox tests
+                    args: --testdox tests
                     bootstrap: vendor/autoload.php
+                    test_suffix: "Test.php" #workaround for https://github.com/php-actions/phpunit/pull/64
                     php_version: "8.3"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"league/commonmark": "^2.3",
 		"nette/php-generator": "^4.0.0",
 		"psr/log": "^3.0.0",
-		"squizlabs/php_codesniffer": "3.*",
+		"squizlabs/php_codesniffer": "^3.9.1",
 		"symfony/console": "^6.1",
 		"twig/markdown-extra": "^3.4",
 		"twig/twig": "^3.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e9e8ade947910345f96765ec101e1b5",
+    "content-hash": "24abf28c38698abaf9fbe36f5cd0860d",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -641,16 +641,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.1",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
                 "shasum": ""
             },
             "require": {
@@ -717,7 +717,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-11T20:47:48+00:00"
+            "time": "2024-03-31T21:03:09+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/Builder/MeetupCollection.php
+++ b/src/Builder/MeetupCollection.php
@@ -57,7 +57,7 @@ class MeetupCollection implements Iterator, Countable
 		return count($this->array);
 	}
 
-	public function append(MeetupEntry $meetup)
+	public function append(MeetupEntry $meetup): void
 	{
 		$this->array[] = $meetup;
 	}

--- a/src/Builder/Processor/HTMLProcessor.php
+++ b/src/Builder/Processor/HTMLProcessor.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 abstract class HTMLProcessor extends AbstractProcessor
 {
-	protected function writeHtml(string $html, string $filename, DateTimeImmutable $modifiedTime = null)
+	protected function writeHtml(string $html, string $filename, DateTimeImmutable $modifiedTime = null): void
 	{
 		$destination = "$this->outputDirectory/$filename";
 		$path = substr($destination, 0, strlen(basename($destination)) * -1);

--- a/src/Builder/Processor/HomepageProcessor.php
+++ b/src/Builder/Processor/HomepageProcessor.php
@@ -6,7 +6,6 @@ namespace MergePHP\Website\Builder\Processor;
 
 use DateTimeImmutable;
 use MergePHP\Website\Builder\MeetupCollection;
-use MergePHP\Website\Meetups;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 

--- a/src/Builder/Processor/MissingLinkProcessor.php
+++ b/src/Builder/Processor/MissingLinkProcessor.php
@@ -20,7 +20,6 @@ class MissingLinkProcessor extends HTMLProcessor
 	public function run(): void
 	{
 		$this->logger->info('Checking for missing YouTube links');
-		$buckets = [];
 
 		foreach ($this->meetups->withOnlyPast() as $meetup) {
 			if ($meetup->instance->getYouTubeLink() === null) {

--- a/src/Builder/SiteBuilderService.php
+++ b/src/Builder/SiteBuilderService.php
@@ -27,7 +27,7 @@ use Twig\Loader\FilesystemLoader;
 
 class SiteBuilderService
 {
-	protected const APP_ROOT = __DIR__ . '/../..';
+	protected const string APP_ROOT = __DIR__ . '/../..';
 	private Environment $twig;
 
 	public function __construct(protected string $outputDirectory, protected LoggerInterface $logger)

--- a/src/Generator/MeetupGeneratorService.php
+++ b/src/Generator/MeetupGeneratorService.php
@@ -23,7 +23,7 @@ class MeetupGeneratorService
 		}
 	}
 
-	protected const SUGGESTED_DATE_FORMAT = 'Y-m-d';
+	protected const string SUGGESTED_DATE_FORMAT = 'Y-m-d';
 
 	public function getSuggestedDate(string $baseDate = 'now'): string
 	{

--- a/tests/AbstractMeetupTest.php
+++ b/tests/AbstractMeetupTest.php
@@ -6,61 +6,51 @@ namespace Tests;
 
 use DateTimeImmutable;
 use MergePHP\Website\AbstractMeetup;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\fixtures\TestMeetup;
 
 class AbstractMeetupTest extends TestCase
 {
-	private function generateMock(string $title): AbstractMeetup|MockObject
-	{
-		$mock = $this->getMockForAbstractClass(AbstractMeetup::class);
-		$mock->method('getTitle')->willReturn($title);
-		return $mock;
-	}
-
 	public function testItGeneratesASlugIgnoringEmojis(): void
 	{
-		$mock = $this->generateMock('50 Ways To Leave Your ♥er');
+		$meetup = new TestMeetup('50 Ways To Leave Your ♥er');
 
-		$this->assertEquals('50-ways-to-leave-your-er', $mock->getSlug());
+		$this->assertEquals('50-ways-to-leave-your-er', $meetup->getSlug());
 	}
 
 	public function testItGeneratesASlugWithoutConsecutiveDashes(): void
 	{
-		$mock = $this->generateMock('First Part - Second Part');
+		$meetup = new TestMeetup('First Part - Second Part');
 
-		$this->assertEquals('first-part-second-part', $mock->getSlug());
+		$this->assertEquals('first-part-second-part', $meetup->getSlug());
 	}
 
 	public function testItGeneratesASlugThatDoesNotStartOrEndWithADash(): void
 	{
-		$mock = $this->generateMock('@ slug !');
+		$meetup = new TestMeetup('@ slug !');
 
-		$this->assertEquals('slug', $mock->getSlug());
+		$this->assertEquals('slug', $meetup->getSlug());
 	}
 
 	public function testItGeneratesASlugThatDoesNotReallyDoWellWithAccentedCharacters(): void
 	{
-		$mock = $this->generateMock('slúg');
+		$meetup = new TestMeetup('slúg');
 
-		$this->assertEquals('sl-g', $mock->getSlug());
+		$this->assertEquals('sl-g', $meetup->getSlug());
 	}
 
 	public function testItReturnsADefaultImageUrlOnlyWhenTheImageIsNotDefined(): void
 	{
-		$mock = $this->getMockForAbstractClass(AbstractMeetup::class);
+		$meetup = new TestMeetup('');
 
-		$this->assertEquals(
-			'/images/placeholder.webp',
-			$mock->getImage(),
-		);
+		$this->assertEquals('/images/placeholder.webp', $meetup->getImage());
 	}
 
 	public function testItAllowsANullYouTubeLink(): void
 	{
-		$mock = $this->getMockForAbstractClass(AbstractMeetup::class);
+		$meetup = new TestMeetup('');
 
-		$this->assertNull($mock->getYouTubeLink());
+		$this->assertNull($meetup->getYouTubeLink());
 	}
 
 	public function testItAllowsTheImageAndYouTubeLinkToBeOverridden(): void

--- a/tests/Builder/Processor/RssFeedProcessorTest.php
+++ b/tests/Builder/Processor/RssFeedProcessorTest.php
@@ -17,7 +17,7 @@ use SimpleXMLElement;
 
 class RssFeedProcessorTest extends TestCase
 {
-	private const string MEETUP_DATE_STRING = '2000-01-01T00:00:00+00:00';
+	public const string MEETUP_DATE_STRING = '2000-01-01T00:00:00+00:00';
 	private const string MODIFIED_DATE_STRING = '2000-01-02T00:00:00+00:00';
 	private const string EXPECTED_FILENAME = 'vfs://root/atom.xml';
 	private const string FIXTURES_DIR = __DIR__ . '/../../fixtures/';
@@ -76,12 +76,32 @@ class RssFeedProcessorTest extends TestCase
 
 	private function generateMeetup(string $description = 'Example description'): AbstractMeetup
 	{
-		$mock = $this->getMockForAbstractClass(AbstractMeetup::class);
-		$mock->method('getTitle')->willReturn('Example Meetup');
-		$mock->method('getDescription')->willReturn($description);
-		$mock->method('getDateTime')->willReturn(new DateTimeImmutable(RssFeedProcessorTest::MEETUP_DATE_STRING));
-		$mock->method('getSpeakerName')->willReturn('Speaker Name');
-		$mock->method('getSpeakerBio')->willReturn('Speaker Bio');
-		return $mock;
+		return new class ($description) extends AbstractMeetup
+		{
+			public function __construct(private readonly string $description)
+			{
+			}
+
+			public function getTitle(): string
+			{
+				return 'Example Meetup';
+			}
+			public function getDescription(): string
+			{
+				return $this->description;
+			}
+			public function getDateTime(): DateTimeImmutable
+			{
+				return new DateTimeImmutable(RssFeedProcessorTest::MEETUP_DATE_STRING);
+			}
+			public function getSpeakerName(): string
+			{
+				return 'Speaker Name';
+			}
+			public function getSpeakerBio(): string
+			{
+				return 'Speaker Bio';
+			}
+		};
 	}
 }

--- a/tests/Builder/Processor/RssFeedProcessorTest.php
+++ b/tests/Builder/Processor/RssFeedProcessorTest.php
@@ -17,10 +17,10 @@ use SimpleXMLElement;
 
 class RssFeedProcessorTest extends TestCase
 {
-	private const MEETUP_DATE_STRING = '2000-01-01T00:00:00+00:00';
-	private const MODIFIED_DATE_STRING = '2000-01-02T00:00:00+00:00';
-	private const EXPECTED_FILENAME = 'vfs://root/atom.xml';
-	private const FIXTURES_DIR = __DIR__ . '/../../fixtures/';
+	private const string MEETUP_DATE_STRING = '2000-01-01T00:00:00+00:00';
+	private const string MODIFIED_DATE_STRING = '2000-01-02T00:00:00+00:00';
+	private const string EXPECTED_FILENAME = 'vfs://root/atom.xml';
+	private const string FIXTURES_DIR = __DIR__ . '/../../fixtures/';
 
 	public function setUp(): void
 	{

--- a/tests/Generator/MeetupGeneratorCommandTest.php
+++ b/tests/Generator/MeetupGeneratorCommandTest.php
@@ -46,14 +46,12 @@ class MeetupGeneratorCommandTest extends TestCase
 		$response = new MeetupGeneratorResponse('foo', 123);
 		$service = $this->createMock(MeetupGeneratorService::class);
 		$service->method('getSuggestedDate')->willReturn('2023-01-01');
-		$service->method('generate')->will(
-			$this->returnValueMap(
-				[
-					// arg1, arg2, arg3, arg4, arg5, arg6, return
-					[...self::COMMAND_1_2_ARGS, $response],
-					[...self::COMMAND_3_ARGS, $response],
-				]
-			)
+		$service->method('generate')->willReturnMap(
+			[
+				// arg1, arg2, arg3, arg4, arg5, arg6, return
+				[...self::COMMAND_1_2_ARGS, $response],
+				[...self::COMMAND_3_ARGS, $response],
+			]
 		);
 
 		$application = new Application();

--- a/tests/Generator/MeetupGeneratorCommandTest.php
+++ b/tests/Generator/MeetupGeneratorCommandTest.php
@@ -14,12 +14,26 @@ use Symfony\Component\Console\Tester\CommandTester;
 class MeetupGeneratorCommandTest extends TestCase
 {
 	// generate args simulate what the user types in to the command line
-	private const GENERATE_1_ARGS  = ['Title', 'Description', null        , 'Name', 'Bio', null];
-	private const GENERATE_2_ARGS  = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', null];
-	private const GENERATE_3_ARGS  = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', 'https://example.com/f.jpg'];
+	private const array GENERATE_1_ARGS  = ['Title', 'Description', null        , 'Name', 'Bio', null];
+	private const array GENERATE_2_ARGS  = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', null];
+	private const array GENERATE_3_ARGS  = [
+		'Title',
+		'Description',
+		'2023-01-01',
+		'Name',
+		'Bio',
+		'https://example.com/f.jpg'
+	];
 	// command args are what the generator command expects to be called with given a certain set of generate args
-	private const COMMAND_1_2_ARGS = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', null];
-	private const COMMAND_3_ARGS   = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', 'https://example.com/f.jpg'];
+	private const array COMMAND_1_2_ARGS = ['Title', 'Description', '2023-01-01', 'Name', 'Bio', null];
+	private const array COMMAND_3_ARGS   = [
+		'Title',
+		'Description',
+		'2023-01-01',
+		'Name',
+		'Bio',
+		'https://example.com/f.jpg'
+	];
 
 	private CommandTester $commandTester;
 

--- a/tests/Generator/MeetupGeneratorServiceTest.php
+++ b/tests/Generator/MeetupGeneratorServiceTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class MeetupGeneratorServiceTest extends TestCase
 {
 	private MeetupGeneratorService $generator;
-	private const FIXTURES_DIR = __DIR__ . '/../fixtures/';
+	private const string FIXTURES_DIR = __DIR__ . '/../fixtures/';
 
 	public function setUp(): void
 	{

--- a/tests/fixtures/TestMeetup.php
+++ b/tests/fixtures/TestMeetup.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\fixtures;
+
+use DateTimeImmutable;
+use MergePHP\Website\AbstractMeetup;
+
+class TestMeetup extends AbstractMeetup
+{
+	public function __construct(private readonly string $title)
+	{
+	}
+
+	public function getTitle(): string
+	{
+		return $this->title;
+	}
+
+	public function getDescription(): string
+	{
+		return 'Description';
+	}
+
+	public function getDateTime(): DateTimeImmutable
+	{
+		return new DateTimeImmutable();
+	}
+
+	public function getSpeakerName(): string
+	{
+		return 'Speaker name';
+	}
+
+	public function getSpeakerBio(): string
+	{
+		return 'Speaker bio';
+	}
+}


### PR DESCRIPTION
* Upgrade PHP Code Sniffer from 3.8.1 to 3.9.1, namely to allow for class constant types
* Remove calls to deprecated PHPUnit method `getMockForAbstractClass`, see https://github.com/sebastianbergmann/phpunit/issues/5241
* Remove calls to depreacated PHPUnit method `returnValueMap` see https://github.com/sebastianbergmann/phpunit/issues/5423