### PR TITLE
Revert "Automatically build website after each meetup"

### DIFF
--- a/.github/workflows/static-deploy.yml
+++ b/.github/workflows/static-deploy.yml
@@ -2,9 +2,6 @@ on:
     push:
         branches:
             - main
-    schedule:
-        # run an hour (no DST) or two hours (DST) after the meetup begins
-        - cron: '0 1 * * 4#2'
 
 jobs:
     build:


### PR DESCRIPTION
This reverts commit 1428edf7052e895540647774e5f446c2f7383cda added in #71. GitHub's error message was:
```
invalid `cron` attribute "0 1 * * 4#2"
```