### PR TITLE
Add detailed PHPDoc comments across various classes and methods

### DIFF
--- a/src/AbstractMeetup.php
+++ b/src/AbstractMeetup.php
@@ -4,8 +4,17 @@ declare(strict_types=1);
 
 namespace MergePHP\Website;
 
+/**
+ * Abstract base class for meetup implementations.
+ * Provides default implementations for common meetup functionality.
+ */
 abstract class AbstractMeetup implements MeetupInterface
 {
+	/**
+	 * Generate a URL-friendly slug from the meetup title.
+	 *
+	 * @return string The slug, or 'untitled' if the title produces an empty slug
+	 */
 	public function getSlug(): string
 	{
 		$slug = $this->getTitle();
@@ -18,16 +27,33 @@ abstract class AbstractMeetup implements MeetupInterface
 		return strlen($slug) ? $slug : 'untitled';
 	}
 
+	/**
+	 * Get the permalink URL for this meetup.
+	 *
+	 * @return string The permalink path
+	 */
 	public function getPermalink(): string
 	{
 		return '/meetups/' . $this->getDateTime()->format('Y/m/d') . "/{$this->getSlug()}.html";
 	}
 
+	/**
+	 * Get the image path for this meetup.
+	 *
+	 * @return string The image path, defaults to placeholder
+	 */
 	public function getImage(): string
 	{
 		return '/images/placeholder.webp';
 	}
 
+	/**
+	 * Get the full URL for the meetup image.
+	 * If the image path is already a full URL, returns it as-is.
+	 * Otherwise, prepends the base URL.
+	 *
+	 * @return string The full image URL
+	 */
 	public function getImageUrl(): string
 	{
 		if (str_starts_with($this->getImage(), 'http')) {
@@ -37,11 +63,21 @@ abstract class AbstractMeetup implements MeetupInterface
 		}
 	}
 
+	/**
+	 * Get the YouTube link for this meetup.
+	 *
+	 * @return string|null The YouTube URL, or null if not available
+	 */
 	public function getYouTubeLink(): ?string
 	{
 		return null;
 	}
 
+	/**
+	 * Get links to meetup event pages.
+	 *
+	 * @return array Array of meetup links
+	 */
 	public function getMeetupLinks(): array
 	{
 		return [];

--- a/src/Builder/MeetupCollection.php
+++ b/src/Builder/MeetupCollection.php
@@ -9,15 +9,23 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Iterator;
 
+/**
+ * Collection of meetup entries with iterator and filtering capabilities.
+ */
 class MeetupCollection implements Iterator, Countable
 {
-	/** @var MeetupEntry[] */
+	/** @var MeetupEntry[] Array of meetup entries */
 	private array $array = [];
+
+	/** @var int Current iterator position */
 	private int $pointer = 0;
 
+	/**
+	 * Sort meetups by date and set up next/previous links.
+	 */
 	public function sort(): void
 	{
-		usort($this-> array, function (MeetupEntry $a, MeetupEntry $b) {
+		usort($this->array, function (MeetupEntry $a, MeetupEntry $b) {
 			return $a->instance->getDateTime() <=> $b->instance->getDateTime();
 		});
 
@@ -27,36 +35,67 @@ class MeetupCollection implements Iterator, Countable
 		}
 	}
 
+	/**
+	 * Get the current meetup entry.
+	 *
+	 * @return MeetupEntry Current entry
+	 */
 	public function current(): MeetupEntry
 	{
 		return $this->array[$this->pointer];
 	}
 
+	/**
+	 * Move to the next meetup entry.
+	 */
 	public function next(): void
 	{
 		$this->pointer++;
 	}
 
+	/**
+	 * Get the current iterator key.
+	 *
+	 * @return int Current position
+	 */
 	public function key(): int
 	{
 		return $this->pointer;
 	}
 
+	/**
+	 * Check if the current position is valid.
+	 *
+	 * @return bool True if position is valid
+	 */
 	public function valid(): bool
 	{
 		return array_key_exists($this->pointer, $this->array);
 	}
 
+	/**
+	 * Reset iterator to the beginning.
+	 */
 	public function rewind(): void
 	{
 		$this->pointer = 0;
 	}
 
+	/**
+	 * Get the number of meetups in the collection.
+	 *
+	 * @return int Number of meetups
+	 */
 	public function count(): int
 	{
 		return count($this->array);
 	}
 
+	/**
+	 * Add a meetup entry to the collection.
+	 *
+	 * @param MeetupEntry $meetup The meetup entry to add
+	 */
 	public function append(MeetupEntry $meetup): void
 	{
 		$this->array[] = $meetup;

--- a/src/Builder/MeetupEntry.php
+++ b/src/Builder/MeetupEntry.php
@@ -7,17 +7,32 @@ namespace MergePHP\Website\Builder;
 use DateTimeImmutable;
 use MergePHP\Website\AbstractMeetup;
 
+/**
+ * Represents a meetup entry with its metadata and navigation links.
+ */
 class MeetupEntry
 {
+	/** @var MeetupEntry|null The next meetup in chronological order */
 	public ?MeetupEntry $next;
+
+	/** @var MeetupEntry|null The previous meetup in chronological order */
 	public ?MeetupEntry $previous;
 
+	/**
+	 * @param AbstractMeetup $instance The meetup instance
+	 * @param DateTimeImmutable $modifiedTimestamp When the meetup file was last modified
+	 */
 	public function __construct(
 		public readonly AbstractMeetup $instance,
 		public readonly DateTimeImmutable $modifiedTimestamp,
 	) {
 	}
 
+	/**
+	 * Get the short class name of the meetup instance.
+	 *
+	 * @return string The class name without namespace
+	 */
 	public function getClassName(): string
 	{
 		return (new \ReflectionClass($this->instance))->getShortName();

--- a/src/Builder/Processor/AbstractProcessor.php
+++ b/src/Builder/Processor/AbstractProcessor.php
@@ -6,13 +6,24 @@ namespace MergePHP\Website\Builder\Processor;
 
 use Psr\Log\LoggerInterface;
 
+/**
+ * Abstract base class for site build processors.
+ * Each processor handles a specific aspect of the site generation.
+ */
 abstract class AbstractProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
 	) {
 	}
 
+	/**
+	 * Execute the processor's build logic.
+	 */
 	abstract public function run(): void;
 }

--- a/src/Builder/Processor/ArchiveProcessor.php
+++ b/src/Builder/Processor/ArchiveProcessor.php
@@ -10,8 +10,18 @@ use MergePHP\Website\Builder\MeetupEntry;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 
+/**
+ * Processor that generates archive pages grouped by year.
+ */
 class ArchiveProcessor extends HTMLProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param MeetupCollection $meetups Collection of all meetups
+	 * @param Environment $twig Twig template environment
+	 * @param array $twigData Common data to pass to all Twig templates
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -22,6 +32,9 @@ class ArchiveProcessor extends HTMLProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate archive pages for each year containing past meetups.
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building archive pages');
@@ -56,7 +69,7 @@ class ArchiveProcessor extends HTMLProcessor
 
 		$previousYear = reset($meetups)->previous?->instance->getDateTime()->format('Y');
 		$nextYear = end($meetups)->next?->instance->getDateTime()->format('Y');
-		if ($nextYear == $year) {
+		if ($nextYear === $year) {
 			$nextYear = null; //this will happen if there is a future meetup scheduled
 		}
 

--- a/src/Builder/Processor/HTMLProcessor.php
+++ b/src/Builder/Processor/HTMLProcessor.php
@@ -7,8 +7,19 @@ namespace MergePHP\Website\Builder\Processor;
 use DateTimeImmutable;
 use RuntimeException;
 
+/**
+ * Base class for processors that generate HTML files.
+ */
 abstract class HTMLProcessor extends AbstractProcessor
 {
+	/**
+	 * Write HTML content to a file in the output directory.
+	 *
+	 * @param string $html The HTML content to write
+	 * @param string $filename The filename relative to output directory
+	 * @param DateTimeImmutable|null $modifiedTime Optional modification time to set on the file
+	 * @throws RuntimeException If the directory cannot be created or file cannot be written
+	 */
 	protected function writeHtml(string $html, string $filename, ?DateTimeImmutable $modifiedTime = null): void
 	{
 		$destination = "$this->outputDirectory/$filename";

--- a/src/Builder/Processor/HomepageProcessor.php
+++ b/src/Builder/Processor/HomepageProcessor.php
@@ -9,8 +9,18 @@ use MergePHP\Website\Builder\MeetupCollection;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 
+/**
+ * Processor that generates the homepage.
+ */
 class HomepageProcessor extends HTMLProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param MeetupCollection $meetups Collection of all meetups
+	 * @param Environment $twig Twig template environment
+	 * @param array $twigData Common data to pass to all Twig templates
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -21,6 +31,9 @@ class HomepageProcessor extends HTMLProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate the homepage with next meetup and archive year.
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building homepage');

--- a/src/Builder/Processor/MeetupProcessor.php
+++ b/src/Builder/Processor/MeetupProcessor.php
@@ -8,8 +8,18 @@ use MergePHP\Website\Builder\MeetupCollection;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 
+/**
+ * Processor that generates individual meetup pages.
+ */
 class MeetupProcessor extends HTMLProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param MeetupCollection $meetups Collection of all meetups
+	 * @param Environment $twig Twig template environment
+	 * @param array $twigData Common data to pass to all Twig templates
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -20,6 +30,9 @@ class MeetupProcessor extends HTMLProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate HTML pages for all meetups.
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building meetup pages');

--- a/src/Builder/Processor/PageNotFoundProcessor.php
+++ b/src/Builder/Processor/PageNotFoundProcessor.php
@@ -7,8 +7,17 @@ namespace MergePHP\Website\Builder\Processor;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 
+/**
+ * Processor that generates the 404 error page.
+ */
 class PageNotFoundProcessor extends HTMLProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param Environment $twig Twig template environment
+	 * @param array $twigData Common data to pass to all Twig templates
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -18,6 +27,9 @@ class PageNotFoundProcessor extends HTMLProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate the 404 error page.
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building 404 page');

--- a/src/Builder/Processor/RSSFeedProcessor.php
+++ b/src/Builder/Processor/RSSFeedProcessor.php
@@ -13,8 +13,16 @@ use RuntimeException;
 
 use function str_contains;
 
+/**
+ * Processor that generates the RSS/Atom feed (atom.xml).
+ */
 class RSSFeedProcessor extends AbstractProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param MeetupCollection $meetups Collection of all meetups
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -23,6 +31,12 @@ class RSSFeedProcessor extends AbstractProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate the Atom RSS feed file.
+	 *
+	 * @throws InvalidContentException If a meetup description contains a <pre> tag
+	 * @throws RuntimeException If the feed cannot be saved or contains invalid XML
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building RSS feed');

--- a/src/Builder/Processor/SitemapChangeFrequency.php
+++ b/src/Builder/Processor/SitemapChangeFrequency.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MergePHP\Website\Builder\Processor;
 
+/**
+ * Enumeration of sitemap change frequency values.
+ */
 enum SitemapChangeFrequency: string
 {
 	case Always  = 'always';

--- a/src/Builder/Processor/SitemapProcessor.php
+++ b/src/Builder/Processor/SitemapProcessor.php
@@ -15,10 +15,19 @@ use RuntimeException;
 use SimpleXMLElement;
 use SplFileInfo;
 
+/**
+ * Processor that generates the sitemap.xml file.
+ */
 class SitemapProcessor extends AbstractProcessor
 {
+	/** @var SimpleXMLElement The sitemap XML document */
 	protected SimpleXMLElement $xml;
 
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param ClockInterface $clock Clock for getting current time
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -27,6 +36,11 @@ class SitemapProcessor extends AbstractProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Generate the sitemap.xml file from all meetup pages.
+	 *
+	 * @throws RuntimeException If the sitemap cannot be saved or contains invalid XML
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Building sitemap');
@@ -74,6 +88,15 @@ class SitemapProcessor extends AbstractProcessor
 		}
 	}
 
+	/**
+	 * Add a URL entry to the sitemap.
+	 *
+	 * @param string $path URL path relative to site root
+	 * @param DateTimeInterface $lastModified Last modification time
+	 * @param float $priority Priority (0.0 to 1.0)
+	 * @param SitemapChangeFrequency $changeFrequency How often the page changes
+	 * @param string|null $image Optional image URL for the page
+	 */
 	protected function appendURL(
 		string $path,
 		DateTimeInterface $lastModified,

--- a/src/Builder/Processor/StaticFileProcessor.php
+++ b/src/Builder/Processor/StaticFileProcessor.php
@@ -11,8 +11,16 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 use SplFileInfo;
 
+/**
+ * Processor that copies static files from the public directory to the output directory.
+ */
 class StaticFileProcessor extends AbstractProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param string $inputDirectory Directory containing static files to copy
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -21,6 +29,11 @@ class StaticFileProcessor extends AbstractProcessor
 		parent::__construct($this->logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Copy all static files from input to output directory.
+	 *
+	 * @throws RuntimeException If a directory cannot be created or file cannot be copied
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Copying static files');

--- a/src/Builder/Processor/YouTubeLinkProcessor.php
+++ b/src/Builder/Processor/YouTubeLinkProcessor.php
@@ -7,8 +7,17 @@ namespace MergePHP\Website\Builder\Processor;
 use MergePHP\Website\Builder\MeetupCollection;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Processor that validates YouTube links for meetups.
+ * Logs warnings for missing links and errors for invalid links.
+ */
 class YouTubeLinkProcessor extends HTMLProcessor
 {
+	/**
+	 * @param LoggerInterface $logger Logger for build output
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param MeetupCollection $meetups Collection of all meetups
+	 */
 	public function __construct(
 		protected LoggerInterface $logger,
 		protected string $outputDirectory,
@@ -17,6 +26,9 @@ class YouTubeLinkProcessor extends HTMLProcessor
 		parent::__construct($logger, $this->outputDirectory);
 	}
 
+	/**
+	 * Check all meetups for missing or invalid YouTube links.
+	 */
 	public function run(): void
 	{
 		$this->logger->info('Checking for missing YouTube links');

--- a/src/Builder/SiteBuilderCommand.php
+++ b/src/Builder/SiteBuilderCommand.php
@@ -14,13 +14,26 @@ use Symfony\Component\Console\Output\OutputInterface;
 	name: 'build',
 	description: 'Build the site',
 )]
+/**
+ * Console command for building the static website.
+ */
 class SiteBuilderCommand extends Command
 {
+	/**
+	 * @param string $outputDirectory Directory where built files are written
+	 */
 	public function __construct(protected string $outputDirectory)
 	{
 		parent::__construct();
 	}
 
+	/**
+	 * Execute the build command.
+	 *
+	 * @param InputInterface $input Input interface
+	 * @param OutputInterface $output Output interface
+	 * @return int Command exit code
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$logger = new ConsoleLogger($output);

--- a/src/Builder/SiteBuilderService.php
+++ b/src/Builder/SiteBuilderService.php
@@ -26,11 +26,22 @@ use Twig\Extension\DebugExtension;
 use Twig\Extra\Markdown\MarkdownExtension;
 use Twig\Loader\FilesystemLoader;
 
+/**
+ * Main service for building the static website.
+ * Orchestrates all processors to generate the complete site.
+ */
 class SiteBuilderService
 {
+	/** @var string Application root directory */
 	protected const string APP_ROOT = __DIR__ . '/../..';
+
+	/** @var Environment Twig template environment */
 	private Environment $twig;
 
+	/**
+	 * @param string $outputDirectory Directory where built files are written
+	 * @param LoggerInterface $logger Logger for build output
+	 */
 	public function __construct(protected string $outputDirectory, protected LoggerInterface $logger)
 	{
 		$this->twig = new Environment(new FilesystemLoader(self::APP_ROOT . '/templates/'), [
@@ -42,6 +53,12 @@ class SiteBuilderService
 		$this->twig->addRuntimeLoader(new TwigRuntimeLoader());
 	}
 
+	/**
+	 * Build the complete static website.
+	 * Runs all processors in sequence to generate all site files.
+	 *
+	 * @throws RuntimeException If build directory cannot be set up or files cannot be written
+	 */
 	public function build(): void
 	{
 		$collection = self::generateMeetupCollection();
@@ -65,6 +82,11 @@ class SiteBuilderService
 		$this->logger->info('Finished successfully');
 	}
 
+	/**
+	 * Ensure the build directory exists and is writable.
+	 *
+	 * @throws RuntimeException If directory cannot be created or is not writable
+	 */
 	protected function setUpBuildDir(): void
 	{
 		if (!file_exists($this->outputDirectory)) {
@@ -79,6 +101,11 @@ class SiteBuilderService
 		}
 	}
 
+	/**
+	 * Delete all existing files and directories in the output directory.
+	 *
+	 * @throws RuntimeException If a file or directory cannot be deleted
+	 */
 	protected function wipeExistingBuild(): void
 	{
 		$this->logger->debug("Wiping $this->outputDirectory");
@@ -104,6 +131,11 @@ class SiteBuilderService
 		$this->logger->info("Wiped output directory of $deletedFiles files and $deletedDirectories directories");
 	}
 
+	/**
+	 * Load all meetup classes from the Meetup directory and create a collection.
+	 *
+	 * @return MeetupCollection Sorted collection of all meetups
+	 */
 	protected static function generateMeetupCollection(): MeetupCollection
 	{
 		$meetups = new MeetupCollection();
@@ -118,6 +150,11 @@ class SiteBuilderService
 		return $meetups;
 	}
 
+	/**
+	 * Generate common variables to pass to all Twig templates.
+	 *
+	 * @return array Array of common template variables
+	 */
 	protected static function generateCommonTwigVars(): array
 	{
 		$meetupLocations = [];

--- a/src/Builder/TwigRuntimeLoader.php
+++ b/src/Builder/TwigRuntimeLoader.php
@@ -9,8 +9,18 @@ use Twig\Extra\Markdown\DefaultMarkdown;
 use Twig\Extra\Markdown\MarkdownRuntime;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
+/**
+ * Runtime loader for Twig extensions, specifically for Markdown support.
+ */
 class TwigRuntimeLoader implements RuntimeLoaderInterface
 {
+	/**
+	 * Load a runtime class for Twig.
+	 *
+	 * @param string $class The class name to load
+	 * @return MarkdownRuntime The runtime instance
+	 * @throws RuntimeException If the class is not supported
+	 */
 	public function load($class): MarkdownRuntime
 	{
 		if (MarkdownRuntime::class === $class) {

--- a/src/Exception/InvalidContentException.php
+++ b/src/Exception/InvalidContentException.php
@@ -6,8 +6,17 @@ namespace MergePHP\Website\Exception;
 
 use Exception;
 
+/**
+ * Exception thrown when meetup content contains invalid markup (e.g., <pre> tags from HEREDOC).
+ */
 class InvalidContentException extends Exception
 {
+	/**
+	 * Create an exception for a meetup class with invalid content.
+	 *
+	 * @param string $className The name of the meetup class with invalid content
+	 * @return InvalidContentException The exception instance
+	 */
 	public static function create(string $className): InvalidContentException
 	{
 		return new self(sprintf(

--- a/src/Generator/MeetupGeneratorCommand.php
+++ b/src/Generator/MeetupGeneratorCommand.php
@@ -16,18 +16,34 @@ use Symfony\Component\Console\Question\Question;
 	name: 'generate',
 	description: 'Generate a new Meetup instance',
 )]
+/**
+ * Console command for interactively generating new meetup class files.
+ */
 class MeetupGeneratorCommand extends Command
 {
+	/**
+	 * @param MeetupGeneratorService $meetupGeneratorService Service for generating meetup files
+	 */
 	public function __construct(protected MeetupGeneratorService $meetupGeneratorService)
 	{
 		parent::__construct();
 	}
 
+	/**
+	 * Configure the command.
+	 */
 	protected function configure(): void
 	{
 		$this->setHelp('This command will prompt for input and generate a new Meetup instance');
 	}
 
+	/**
+	 * Execute the command.
+	 *
+	 * @param InputInterface $input Input interface
+	 * @param OutputInterface $output Output interface
+	 * @return int Command exit code
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$helper = $this->getHelper('question');
@@ -54,6 +70,14 @@ class MeetupGeneratorCommand extends Command
 		return Command::SUCCESS;
 	}
 
+	/**
+	 * Handle MissingInputException that occurs on Windows when running through Composer.
+	 *
+	 * @param MissingInputException $e The exception that was thrown
+	 * @param OutputInterface $output Output interface
+	 * @param bool $isInteractive Whether the command is running in interactive mode
+	 * @return int Command exit code
+	 */
 	protected function handleFirstMissingInputException(
 		MissingInputException $e,
 		OutputInterface $output,

--- a/src/Generator/MeetupGeneratorResponse.php
+++ b/src/Generator/MeetupGeneratorResponse.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace MergePHP\Website\Generator;
 
+/**
+ * Response object containing information about a generated meetup file.
+ */
 class MeetupGeneratorResponse
 {
+	/**
+	 * @param string $filename Path to the generated file
+	 * @param int $bytesWritten Number of bytes written to the file
+	 */
 	public function __construct(
 		public readonly string $filename,
 		public readonly int $bytesWritten,

--- a/src/Generator/MeetupGeneratorService.php
+++ b/src/Generator/MeetupGeneratorService.php
@@ -14,8 +14,15 @@ use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\Printer;
 use RuntimeException;
 
+/**
+ * Service for generating meetup class files.
+ */
 class MeetupGeneratorService
 {
+	/**
+	 * @param string $directory Directory where meetup files are stored
+	 * @throws RuntimeException If the directory is not writable
+	 */
 	public function __construct(public string $directory)
 	{
 		if (!is_writable($this->directory)) {
@@ -23,8 +30,15 @@ class MeetupGeneratorService
 		}
 	}
 
+	/** @var string Date format for suggested dates */
 	protected const string SUGGESTED_DATE_FORMAT = 'Y-m-d';
 
+	/**
+	 * Get a suggested date for the next meetup (second Thursday of current or next month).
+	 *
+	 * @param string $baseDate Base date to calculate from (default: 'now')
+	 * @return string Suggested date in Y-m-d format
+	 */
 	public function getSuggestedDate(string $baseDate = 'now'): string
 	{
 		/** @noinspection PhpUnhandledExceptionInspection */
@@ -39,7 +53,7 @@ class MeetupGeneratorService
 			}
 			$thursdays = 0;
 			do {
-				if ($date->format('D') == 'Thu') {
+				if ($date->format('D') === 'Thu') {
 					$thursdays++;
 				}
 				$date = $date->add(new DateInterval('P1D'));
@@ -52,6 +66,17 @@ class MeetupGeneratorService
 		return $fallback->format(self::SUGGESTED_DATE_FORMAT); // this should not happen
 	}
 
+	/**
+	 * Generate a new meetup class file.
+	 *
+	 * @param string $title Meetup title
+	 * @param string $description Meetup description (markdown supported)
+	 * @param string $date Meetup date in Y-m-d format
+	 * @param string $speakerName Speaker's name
+	 * @param string $speakerBio Speaker's bio (markdown supported)
+	 * @param string|null $image Optional image URL or path
+	 * @return MeetupGeneratorResponse Response containing filename and bytes written
+	 */
 	public function generate(
 		string $title,
 		string $description,

--- a/src/MeetupInterface.php
+++ b/src/MeetupInterface.php
@@ -6,14 +6,65 @@ namespace MergePHP\Website;
 
 use DateTimeImmutable;
 
+/**
+ * Interface for meetup implementations.
+ * Defines the contract for all meetup data classes.
+ */
 interface MeetupInterface
 {
+	/**
+	 * Get the meetup title.
+	 *
+	 * @return string The title
+	 */
 	public function getTitle(): string;
+
+	/**
+	 * Get the meetup description (markdown supported).
+	 *
+	 * @return string The description
+	 */
 	public function getDescription(): string;
+
+	/**
+	 * Get the meetup date and time.
+	 *
+	 * @return DateTimeImmutable The date and time
+	 */
 	public function getDateTime(): DateTimeImmutable;
+
+	/**
+	 * Get the image path or URL for the meetup.
+	 *
+	 * @return string The image path or URL
+	 */
 	public function getImage(): string;
+
+	/**
+	 * Get the speaker's name.
+	 *
+	 * @return string The speaker name
+	 */
 	public function getSpeakerName(): string;
+
+	/**
+	 * Get the speaker's bio (markdown supported).
+	 *
+	 * @return string The speaker bio
+	 */
 	public function getSpeakerBio(): string;
+
+	/**
+	 * Get the YouTube link for the meetup recording.
+	 *
+	 * @return string|null The YouTube URL, or null if not available
+	 */
 	public function getYouTubeLink(): ?string;
+
+	/**
+	 * Get links to meetup event pages.
+	 *
+	 * @return array Array of meetup links
+	 */
 	public function getMeetupLinks(): array;
 }

--- a/src/Meetups.php
+++ b/src/Meetups.php
@@ -2,6 +2,9 @@
 
 namespace MergePHP\Website;
 
+/**
+ * Enumeration of MergePHP meetup locations.
+ */
 enum Meetups: string
 {
 	case Atlanta = 'Atlanta';

--- a/tests/Generator/MeetupGeneratorCommandTest.php
+++ b/tests/Generator/MeetupGeneratorCommandTest.php
@@ -39,7 +39,7 @@ class MeetupGeneratorCommandTest extends TestCase
 
 	public function setUp(): void
 	{
-		if (PHP_OS_FAMILY == 'Windows') {
+		if (PHP_OS_FAMILY === 'Windows') {
 			$this->markTestSkipped('This test can\'t run on Windows :(');
 		}
 


### PR DESCRIPTION
This commit enhances code documentation by adding PHPDoc comments to classes, methods, and properties in the project. It improves clarity and maintainability, providing descriptions for functionality, parameters, and return types in the AbstractMeetup, MeetupInterface, and various processor classes, among others.