### PR TITLE
Automatically build and deploy website every week

### DIFF
--- a/.github/workflows/static-deploy.yml
+++ b/.github/workflows/static-deploy.yml
@@ -3,6 +3,11 @@ on:
         branches:
             - main
 
+    schedule:
+        # regenerate and redeploy the site every Thursday at 9pm Eastern
+        - cron: "0 21 * * THU"
+          timezone: "America/New_York"
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
First added in #71 and then reverted in #76 because the syntax wasn't supported.  This will build and deploy the main branch every Thursday night.  The second Thursday of the month the site will regenerate the homepage so the next meetup (if any) is shown