### PR TITLE
Upgrade to PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,6 @@ jobs:
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
-                with:
-                    php-version: '8.4'
 
             -   name: Install PHP dependencies
                 run: composer install

--- a/.github/workflows/static-deploy.yml
+++ b/.github/workflows/static-deploy.yml
@@ -18,8 +18,6 @@ jobs:
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 8.4
 
             -   name: Install PHP dependencies
                 run: composer install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Tests
 
 on:
     workflow_dispatch:
@@ -13,15 +13,17 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v6
-
-            -   name: Setup composer
-                uses: php-actions/composer@v6
                 with:
-                    php_version: 8.4
+                    fetch-depth: 0
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+
+            -   name: Install PHP dependencies
+                run: composer install
 
             -   name: Run PHPUnit Tests
-                uses: php-actions/phpunit@v4
-                with:
-                    args: --testdox tests
-                    bootstrap: vendor/autoload.php
-                    php_version: "8.4"
+                run: composer test
+
+            -   name: Smoke test
+                run: composer build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli
+FROM php:8.5-cli
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Prerequisites
 
 This project's dependencies are installed with [composer](https://getcomposer.org/).
 
-You must have PHP 8.4 running on your machine (or be willing to build in a container with 8.4
+You must have PHP 8.5 running on your machine (or be willing to build in a container with 8.5
 installed)
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"config": {
 		"platform": {
-			"php": "8.4"
+			"php": "8.5"
 		}
 	},
 	"require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "864e5445e902e78255a1d3cb724d5da1",
+    "content-hash": "66d66089143742cfff3e5fb85e489762",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -3625,7 +3625,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.4"
+        "php": "8.5"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
* Update composer.json/composer.lock for new version
* Update README
* Update Dockerfile
* Update CI/CD
  * Remove hardcoded php-version variable as [it will be read from composer.lock](https://github.com/shivammathur/setup-php#php-version-optional)
  * Consolidate all actions to use shivammathur/setup-php instead of setup-php/*
* Add site build to the `test` step as a smoke test

This also fixes the current build issue as SVG size information was not added to getimagesize [until PHP 8.5](https://bugs.php.net/bug.php?id=71517)