### PR TITLE
Fix Docker build on PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,11 @@ RUN apt-get update && apt-get install -y \
     git \
     unzip \
     libzip-dev \
-    libxml2-dev \
-    libonig-dev \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHP extensions required by the project
 RUN docker-php-ext-install zip
-RUN docker-php-ext-install dom
-RUN docker-php-ext-install simplexml
-RUN docker-php-ext-install mbstring
 RUN docker-php-ext-configure pcntl --enable-pcntl && docker-php-ext-install pcntl
 
 # Install Composer


### PR DESCRIPTION
When I ran `docker compose up --build -d`, I got errors when Docker tried to build the DOM extension. Since the DOM extension is built-in to the base image, the install for the DOM extension is an unneeded step. Also extraneous are mbstring and simpleXml

This change removes redundant PHP extension builds from Dockerfile.

After building the Docker container with this change, I can go into the container's shell and run `php -m` to get:

```
[PHP Modules]
Core
ctype
curl
date
dom
fileinfo
filter
hash
iconv
json
lexbor
libxml
mbstring
mysqlnd
openssl
pcntl
pcre
PDO
pdo_sqlite
Phar
posix
random
readline
Reflection
session
SimpleXML
sodium
SPL
sqlite3
standard
tokenizer
uri
xml
xmlreader
xmlwriter
Zend OPcache
zip
zlib

[Zend Modules]
Zend OPcache
```