### PR TITLE
Rename link to show new purpose

### DIFF
--- a/templates/index.twig.html
+++ b/templates/index.twig.html
@@ -42,7 +42,7 @@
 			<h3><a href="https://mphp.io/speakers">Speaker Signups</a></h3>
 			<h3><a href="https://mphp.io/suggest">Suggest Speakers</a></h3>
 			<h3><a href="/groups/">Affiliated Groups</a></h3>
-			<h3><a href="/meetups/{{ archiveYear }}/">View past meetups</a></h3>
+			<h3><a href="/meetups/{{ archiveYear }}/">View all meetups</a></h3>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
A recent change made the link show all past, current, and known upcoming  events. The link has been renamed to show this purpose.