### PR TITLE
Test docker via gh actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_size = 4
 indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
         branches:
             - main
         paths:
+            - composer.lock
+            - composer.json
             - Dockerfile
             - docker-compose.yml
             - docker-entrypoint.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+    workflow_dispatch:
+    pull_request:
+        branches:
+            - main
+        paths:
+            - Dockerfile
+            - docker-compose.yml
+            - docker-entrypoint.sh
+            - .dockerignore
+            - .github/workflows/docker.yml
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v6
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v3
+
+            -   name: Validate Docker Compose config
+                run: docker compose config --quiet
+
+            -   name: Build Docker image
+                uses: docker/build-push-action@v6
+                with:
+                    context: .
+                    file: ./Dockerfile
+                    load: true
+                    tags: mergephp-website-app:ci
+                    cache-from: type=gha
+                    cache-to: type=gha,mode=max
+
+            -   name: Install PHP dependencies in container
+                run: docker compose run --rm app composer install --no-interaction --prefer-dist
+
+            -   name: Build website in container
+                run: docker compose run --rm app composer build
+
+            -   name: Start container
+                run: docker compose up -d app
+
+            -   name: Smoke test website
+                run: curl --fail --retry 10 --retry-delay 2 --retry-connrefused http://localhost:8000/
+
+            -   name: Show Docker logs on failure
+                if: failure()
+                run: docker compose logs app
+
+            -   name: Stop containers
+                if: always()
+                run: docker compose down --volumes --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   app:
+    image: mergephp-website-app:ci
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This Github Action will build the docker container and run the smoke tests in the following situations:

- When a docker file (`dockerfile`, `docker-compose.yml`, etc) changes, we should run a smoke test to make sure the container still builds correctly.
- When a package is added to `docker-compose.yml`, it might require a PHP extension that is not yet defined in the `dockerfile`.  This gh Action will fail on the build, which should inform the developer that the extension needs to be added to the `dockerfile`.

All other PRs would not do a full build of the docker container since they would be using cached layers, nor would they run these tests.