### PR TITLE
Prevent generating nested p tags

### DIFF
--- a/templates/index.twig.html
+++ b/templates/index.twig.html
@@ -11,11 +11,11 @@
 				<time datetime="{{ nextMeetup.getDateTime().format('c') }}" style="display:inline" data-localize="date">{{ nextMeetup.getDateTime().format('F jS, Y') }}</time>
 				as {{ nextMeetup.getSpeakerName() }} presents</p>
 			<h2 class="mb-4 font-weight-bold">{{ nextMeetup.getTitle() }}</h2>
-			<p class="m-0">
+			<div class="m-0">
 				{{ nextMeetup.getDescription()|markdown_to_html }}
-			</p>
+			</div>
 			<h3>Presented by {{ nextMeetup.getSpeakerName() }}</h3>
-			<p>{{ nextMeetup.getSpeakerBio()|markdown_to_html }}</p>
+			{{ nextMeetup.getSpeakerBio()|markdown_to_html }}
 		</div>
 	</div>
 </div>

--- a/templates/meetup.twig.html
+++ b/templates/meetup.twig.html
@@ -21,7 +21,7 @@
 			</article>
 
 			<h3>Presented by {{ meetup.getSpeakerName() }}</h3>
-			<p>{{ meetup.getSpeakerBio()|markdown_to_html }}</p>
+			{{ meetup.getSpeakerBio()|markdown_to_html }}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
The `markdown_to_html` function already surrounds text in <p></p> tags, so we can safely remove them here.

Fixes #61 